### PR TITLE
chore(ui): disable password input field for consistency

### DIFF
--- a/src/app/components/password-display/password-display.component.html
+++ b/src/app/components/password-display/password-display.component.html
@@ -4,6 +4,7 @@
     class="mr-4 w-full bg-transparent text-2xl"
     value="{{ password() }}"
     placeholder="P4$5W0rD"
+    disabled
   />
   <div class="relative flex items-center justify-end gap-4">
     <span class="ml-4 uppercase text-accent" [class.hidden]="!showCopied"


### PR DESCRIPTION
- Added the `disabled` attribute to the password input field in `password-display.component.html` to prevent user interaction and maintain consistency with the read-only display.